### PR TITLE
index: fix index merging on windows

### DIFF
--- a/cmd/cindex/cindex.go
+++ b/cmd/cindex/cindex.go
@@ -320,7 +320,10 @@ func main() {
 		log.Printf("merge %s %s", master, file)
 		index.Merge(file+"~", master, file)
 		os.Remove(file)
-		os.Rename(file+"~", master)
+		os.Remove(master)
+		if err := os.Rename(file+"~", master); err != nil {
+			log.Fatalf("failed to merge indexes: %s", err)
+		}
 	}
 	log.Printf("done")
 	return


### PR DESCRIPTION
Rename fails on Windows if destination exists.

The following sequence will now correctly work:

  $ cindex a
  $ cindex b

instead of silently failing to update the index with b content.
